### PR TITLE
Add caching system, set to 60s by defult.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -63,18 +63,22 @@ GET /?url=www.google.com&callback=http://www.myservice.com/screenshot/google
 GET /form.html
 ```
 
+Screenshots are cached for one minute, so that frequent requests for the same screenshot don't slow the service down. You can adjust or disable caching in the project configuration (see below).
+
 ## Configuration
 
 Create a `config/development.yaml` or a `config/production.yaml` to override any of the settings found in the `config/default.yaml`:
 
 ```yml
 rasterizer:
-  command: phantomjs
-  port: 3001
-  path: '/tmp/'
-  viewport: '1024x600'
+  command: phantomjs   # phantomjs executable
+  port: 3001           # internal service port. No need to allow inbound or outbound access to this port
+  path: '/tmp/'        # where the screenshot files are stored
+  viewport: '1024x600' # browser window size. Height frows according to the content
+cache:
+  lifetime: 60000      # one minute, set to 0 for no cache
 server:
-  port: 3000
+  port: 3000           # main service port
 ```
 
 For instance, if you want to setup a proxy for phantomjs, create a `config/development.yaml` as follows:

--- a/app.js
+++ b/app.js
@@ -4,11 +4,7 @@
 var config = require('config');
 var express = require('express');
 var RasterizerService = require('./lib/rasterizerService');
-
-// rasterizer
-var rastconfig = config.rasterizer;
-var rasterizerService = new RasterizerService(rastconfig);
-rasterizerService.startService();
+var FileCleanerService = require('./lib/fileCleanerService');
 
 process.on('uncaughtException', function (err) {
   console.error("[uncaughtException]", err);
@@ -28,7 +24,8 @@ var app = express.createServer();
 app.configure(function(){
   app.use(express.static(__dirname + '/public'))
   app.use(app.router);
-  app.set('rasterizerService', rasterizerService);
+  app.set('rasterizerService', new RasterizerService(config.rasterizer).startService());
+  app.set('fileCleanerService', new FileCleanerService(config.cache.lifetime));
 });
 app.configure('development', function() {
   app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,7 +1,9 @@
 rasterizer:
-  command: phantomjs
-  port: 3001
-  path: '/tmp/'
-  viewport: '1024x600'
+  command: phantomjs   # phantomjs executable
+  port: 3001           # internal service port. No need to allow inbound or outbound access to this port
+  path: '/tmp/'        # where the screenshot files are stored
+  viewport: '1024x600' # browser window size. Height frows according to the content
+cache:
+  lifetime: 60000      # one minute, set to 0 for no cache
 server:
-  port: 3000
+  port: 3000           # main service port

--- a/lib/fileCleanerService.js
+++ b/lib/fileCleanerService.js
@@ -1,0 +1,50 @@
+/**
+ * Module dependencies.
+ */
+var fs = require('fs');
+
+/**
+ * File cleaner service.
+ *
+ * The service cleans up files after a certain time.
+ * The constructor expects the file lifetime, in milliseconds.
+ *
+ * @param {int} cache lifetime in microseconds, default to 1 minute.
+ *              When set to 0, adding a file causes its deletion at the next tick
+ * @api public
+ */
+var FileCleanerService = function(ttl) {
+  this.ttl = typeof ttl === 'undefined' ? 60000 : ttl;
+  this.files = {};
+  var self = this;
+  process.on('exit', function() {
+    self.removeAllFiles();
+  });
+}
+
+FileCleanerService.prototype.addFile = function(path) {
+  if (typeof this.files[path] != 'undefined') {
+    // do nothing. The file will expire sooner than expected
+    return;
+  }
+  var self = this;
+  this.files[path] = setTimeout(function() {
+    self.removeFile(path);
+  }, this.ttl);
+}
+
+FileCleanerService.prototype.removeFile = function(path) {
+  if (typeof this.files[path] == 'undefined') {
+    throw new Error('File ' + path + 'is not managed by the cleaner service');
+  }
+  delete this.files[path];
+  fs.unlinkSync(path);
+}
+
+FileCleanerService.prototype.removeAllFiles = function() {
+  for (path in this.files) {
+    this.removeFile(path);
+  }
+}
+
+module.exports = FileCleanerService;

--- a/lib/rasterizerService.js
+++ b/lib/rasterizerService.js
@@ -52,6 +52,7 @@ RasterizerService.prototype.startService = function() {
   this.pingServiceIntervalId = setInterval(this.pingService.bind(this), this.pingDelay);
   this.checkHealthIntervalId = setInterval(this.checkHealth.bind(this), 1000);
   console.log('Phantomjs internal server listening on port ' + this.config.port);
+  return this;
 }
 
 RasterizerService.prototype.killService = function() {

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,69 +1,112 @@
 var utils = require('../lib/utils');
 var join = require('path').join;
 var fs = require('fs');
+var path = require('path');
 var request = require('request');
-var spawn = require('child_process').spawn;
 
 module.exports = function(app) {
+  var rasterizerService = app.settings.rasterizerService;
+  var fileCleanerService = app.settings.fileCleanerService;
+
+  // routes
   app.get('/', function(req, res, next) {
     if (!req.param('url', false)) {
       return res.redirect('/usage.html');
     }
+
     var url = utils.url(req.param('url'));
-    var id = utils.md5(url + Date.now());
-    var filename = id + '.png';
-    var rasterizerService = app.settings.rasterizerService;
-    var path = join(rasterizerService.getPath(), filename);
     // required options
     var options = {
       uri: 'http://localhost:' + rasterizerService.getPort() + '/',
-      headers: { url: url, filename: filename }
+      headers: { url: url }
     };
     ['width', 'height', 'clipRect', 'javascriptEnabled', 'loadImages', 'localToRemoteUrlAccessEnabled', 'userAgent', 'userName', 'password'].forEach(function(name) {
       if (req.param(name, false)) options.headers[name] = req.param(name);
     });
 
-    console.log('screenshot - rasterizing %s', url);
+    var filename = 'screenshot_' + utils.md5(url + JSON.stringify(options)) + '.png';
+    options.headers.filename = filename;
 
-    if (req.param('callback', false)) {
-      // asynchronous
-      var callback = utils.url(req.param('callback'));
-      res.send('Will post screenshot of ' + url + ' to ' + callback + ' when processed');
-      request.get(options, function(err) {
-        // FIXME: call the callback with an error
-        if (err) {
-          console.log(err.message);
-          rasterizerService.restartService();
-          return;
-        }
-        console.log('screenshot - streaming to %s', callback);
-        var fileStream = fs.createReadStream(path);
-        fileStream.on('end', function() {
-          fs.unlink(path);
-        });
-        fileStream.on('error', function(err){
-          console.log('Error handled in file reader: %s', err.message);
-        });
-        fileStream.pipe(request.post(callback, function(err) {
-          if (err) console.log('Error while streaming screenshot: %s', err);
-        }));
-      });
-    } else {
-      // synchronous
-      request.get(options, function(error, response, body) {
-        if (error || response.statusCode != 200) {
-          return next(new Error(body));
-        }
-        console.log('screenshot - sending response');
-        res.sendfile(path, function(err) {
-          fs.unlink(path);
-        });
-      });
+    var filePath = join(rasterizerService.getPath(), filename);
+
+    var callbackUrl = req.param('callback', false) ? utils.url(req.param('callback')) : false;
+
+    if (path.existsSync(filePath)) {
+      console.log('Request for %s - Found in cache', url);
+      processImageUsingCache(filePath, res, callbackUrl, function(err) { if (err) next(err); });
+      return;
     }
+    console.log('Request for %s - Rasterizing it', url);
+    processImageUsingRasterizer(options, filePath, res, callbackUrl, function(err) { if(err) next(err); });
   });
 
   app.get('*', function(req, res, next) {
     // for backwards compatibility, try redirecting to the main route if the request looks like /www.google.com
     res.redirect('/?url=' + req.url.substring(1));
   });
+
+  // bits of logic
+  var processImageUsingCache = function(filePath, res, url, callback) {
+    if (url) {
+      // asynchronous
+      res.send('Will post screenshot to ' + url + ' when processed');
+      postImageToUrl(filePath, url, callback);
+    } else {
+      // synchronous
+      sendImageInResponse(filePath, res, callback);
+    }
+  }
+
+  var processImageUsingRasterizer = function(rasterizerOptions, filePath, res, url, callback) {
+    if (url) {
+      // asynchronous
+      res.send('Will post screenshot to ' + url + ' when processed');
+      callRasterizer(rasterizerOptions, function(error) {
+        if (error) return callback(error);
+        postImageToUrl(filePath, url, callback);
+      });
+    } else {
+      // synchronous
+      callRasterizer(rasterizerOptions, function(error) {
+        if (error) return callback(error);
+        sendImageInResponse(filePath, res, callback);
+      });
+    }
+  }
+
+  var callRasterizer = function(rasterizerOptions, callback) {
+    request.get(rasterizerOptions, function(error, response, body) {
+      if (error || response.statusCode != 200) {
+        console.log('Error while requesting the rasterizer: %s', error.message);
+        rasterizerService.restartService();
+        return callback(new Error(body));
+      }
+      callback(null);
+    });
+  }
+
+  var postImageToUrl = function(imagePath, url, callback) {
+    console.log('Streaming image to %s', url);
+    var fileStream = fs.createReadStream(imagePath);
+    fileStream.on('end', function() {
+      fileCleanerService.addFile(imagePath);
+    });
+    fileStream.on('error', function(err){
+      console.log('Error while reading file: %s', err.message);
+      callback(err);
+    });
+    fileStream.pipe(request.post(url, function(err) {
+      if (err) console.log('Error while streaming screenshot: %s', err);
+      callback(err);
+    }));
+  }
+
+  var sendImageInResponse = function(imagePath, res, callback) {
+    console.log('Sending image in response');
+    res.sendfile(imagePath, function(err) {
+      fileCleanerService.addFile(imagePath);
+      callback(err);
+    });
+  }
+
 };


### PR DESCRIPTION
This is my take on caching.

The service returns the same image for 60s for a given set of url+options. This behavior can be disabled by configuring the cache lifetime to 0.

Refactored the main route for better clarity.
