### PR TITLE
made addition phantomjs arguments configurable through yaml file.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -77,6 +77,7 @@ Create a `config/development.yaml` or a `config/production.yaml` to override any
 ```yml
 rasterizer:
   command: phantomjs   # phantomjs executable
+  args: ''             # additional phantomjs arguments
   port: 3001           # internal service port. No need to allow inbound or outbound access to this port
   path: '/tmp/'        # where the screenshot files are stored
   viewport: '1024x600' # browser window size. Height frows according to the content
@@ -90,7 +91,7 @@ For instance, if you want to setup a proxy for phantomjs, create a `config/devel
 
 ```yml
 rasterizer:
-  command: 'phantomjs --proxy=myproxy:1234'
+   args: '--proxy=myproxy:1234'
 ```
 
 ## Asynchronous Usage Example

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,5 +1,6 @@
 rasterizer:
   command: phantomjs   # phantomjs executable
+  args: ''             # additional phantomjs arguments
   port: 3001           # internal service port. No need to allow inbound or outbound access to this port
   path: '/tmp/'        # where the screenshot files are stored
   viewport: '1024x600' # browser window size. Height frows according to the content

--- a/lib/rasterizerService.js
+++ b/lib/rasterizerService.js
@@ -12,6 +12,7 @@ var request = require('request');
  *
  * The constructor expects a configuration object as parameter, with these properties:
  *   command: Command to start a phantomjs process
+ *   args : Additional phantomjs commandline arguments
  *   port: Server listerner port
  *   path: Destination of temporary images
  *   viewport: Width and height represent the viewport size (format: '1024x800')
@@ -34,7 +35,7 @@ var RasterizerService = function(config) {
 }
 
 RasterizerService.prototype.startService = function() {
-  var rasterizer = spawn(this.config.command, ['scripts/rasterizer.js', this.config.path, this.config.port, this.config.viewport]);
+  var rasterizer = spawn(this.config.command, [this.config.args, 'scripts/rasterizer.js', this.config.path, this.config.port, this.config.viewport]);
   var self = this;
   rasterizer.stderr.on('data', function (data) {
     console.log('phantomjs error: ' + data);


### PR DESCRIPTION
The following configuration example does not work.

``` yaml
rasterizer:
  command: 'phantomjs --proxy=myproxy:1234'
```

It causes:

``` log
phantomjs failed; restarting
[uncaughtException] { [Error: spawn EMFILE] code: 'EMFILE', errno: 'EMFILE', syscall: 'spawn' }
```

made addition phantomjs arguments configurable through yaml file.
