### PR TITLE
Don't crash if image doesn't exist. Related to #32

### DIFF
--- a/lib/fileCleanerService.js
+++ b/lib/fileCleanerService.js
@@ -38,7 +38,11 @@ FileCleanerService.prototype.removeFile = function(path) {
     throw new Error('File ' + path + 'is not managed by the cleaner service');
   }
   delete this.files[path];
-  fs.unlinkSync(path);
+  try {
+    fs.unlinkSync(path);
+  } catch(e) {
+    console.error(e);
+  }
 }
 
 FileCleanerService.prototype.removeAllFiles = function() {


### PR DESCRIPTION
Catch error if trying to unlink a file that has been already removed by either a prior simultaneous request or some other application.
