### PR TITLE
Enable CORS

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,6 @@ app.configure(function(){
 app.configure('development', function() {
   app.use(express.errorHandler({ dumpExceptions: true, showStack: true }));
 });
-require('./routes')(app);
+require('./routes')(app, config.server.useCors);
 app.listen(config.server.port);
 console.log('Express server listening on port ' + config.server.port);

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -7,3 +7,4 @@ cache:
   lifetime: 60000      # one minute, set to 0 for no cache
 server:
   port: 3000           # main service port
+  useCors: false       # enable CORS support

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,7 +4,7 @@ var fs = require('fs');
 var path = require('path');
 var request = require('request');
 
-module.exports = function(app) {
+module.exports = function(app, useCors) {
   var rasterizerService = app.settings.rasterizerService;
   var fileCleanerService = app.settings.fileCleanerService;
 
@@ -103,6 +103,10 @@ module.exports = function(app) {
 
   var sendImageInResponse = function(imagePath, res, callback) {
     console.log('Sending image in response');
+    if (useCors) {
+      res.setHeader("Access-Control-Allow-Origin", "*");
+      res.setHeader("Access-Control-Expose-Headers", "Content-Type");
+    }
     res.sendfile(imagePath, function(err) {
       fileCleanerService.addFile(imagePath);
       callback(err);


### PR DESCRIPTION
Adding CORS support (http://www.html5rocks.com/en/tutorials/cors/).

This allows browsers to directly load images from the server via a XMLHttpRequest.

Disabled by default. Can be turned on by setting

```
server:
  useCors: true
```

The two headers do the following
- Enable CORS
- Allow the client JS to access the Content-Type header.
