### PR TITLE
Do not start 2 new rasterizers on restart.

### DIFF
--- a/lib/rasterizerService.js
+++ b/lib/rasterizerService.js
@@ -41,7 +41,6 @@ RasterizerService.prototype.rasterizerExitHandler = function (code) {
 
 RasterizerService.prototype.startService = function() {
   var rasterizer = spawn(this.config.command, ['scripts/rasterizer.js', this.config.path, this.config.port, this.config.viewport]);
-  var self = this;
   rasterizer.stderr.on('data', function (data) {
     console.log('phantomjs error: ' + data);
   });


### PR DESCRIPTION
`restartService` kills the rasterizer and starts a new one, but the killed rasterizer also calls `startService` on its own `exit` event. As a result, every time `restartService` is called, 2 new rasterizers are spawned for the 1 killed.

Since the automatic `startService` on `exit` should remain intact, the `startService` within `restartService` should be removed.

This is probably related to what @lahdekorpi and @HaNdTriX report in #32.
