### PR TITLE
Webservice crashes when child process exits

### DIFF
--- a/lib/rasterizerService.js
+++ b/lib/rasterizerService.js
@@ -4,6 +4,7 @@
 
 var spawn = require('child_process').spawn;
 var request = require('request');
+var self;
 
 /**
  * Rasterizer service.
@@ -26,7 +27,7 @@ var RasterizerService = function(config) {
   this.pingDelay = 10000; // every 10 seconds
   this.sleepTime = 30000; // three failed health checks, 30 seconds
   this.lastHealthCheckDate = null;
-  var self = this;
+  self = this;
   process.on('exit', function() {
     self.isStopping = true;
     self.killService();
@@ -47,7 +48,9 @@ RasterizerService.prototype.startService = function() {
   rasterizer.stdout.on('data', function (data) {
     console.log('phantomjs output: ' + data);
   });
-  rasterizer.on('exit', this.rasterizerExitHandler);
+  rasterizer.on('exit', function() {
+      self.restartService();
+  });
   this.rasterizer = rasterizer;
   this.lastHealthCheckDate = Date.now();
   this.pingServiceIntervalId = setInterval(this.pingService.bind(this), this.pingDelay);


### PR DESCRIPTION
Hello,

When the phantomjs child process crashes, the webservice would not correctly restarts. I've just done a small fix for that.
