### PR TITLE
#66 Add better support for HTTPS websites by default

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,5 +1,7 @@
 rasterizer:
   command: phantomjs   # phantomjs executable
+  options: 
+    - '--ssl-protocol=any' # Better support for HTTPS urls!
   port: 3001           # internal service port. No need to allow inbound or outbound access to this port
   path: '/tmp/'        # where the screenshot files are stored
   viewport: '1024x600' # browser window size. Height frows according to the content

--- a/lib/rasterizerService.js
+++ b/lib/rasterizerService.js
@@ -40,7 +40,11 @@ RasterizerService.prototype.rasterizerExitHandler = function (code) {
 };
 
 RasterizerService.prototype.startService = function() {
-  var rasterizer = spawn(this.config.command, ['scripts/rasterizer.js', this.config.path, this.config.port, this.config.viewport]);
+
+  var options = this.config.options || [];
+  var args = options.concat(['scripts/rasterizer.js', this.config.path, this.config.port, this.config.viewport]);
+  console.log('RasterizerService starting with ' + JSON.stringify(args));
+  var rasterizer = spawn(this.config.command,args);
   rasterizer.stderr.on('data', function (data) {
     console.log('phantomjs error: ' + data);
   });

--- a/routes/index.js
+++ b/routes/index.js
@@ -77,9 +77,10 @@ module.exports = function(app, useCors) {
   var callRasterizer = function(rasterizerOptions, callback) {
     request.get(rasterizerOptions, function(error, response, body) {
       if (error || response.statusCode != 200) {
-        console.log('Error while requesting the rasterizer: %s', error.message);
+        var effectiveError = error ? error : new Error('Bad rasterizer response. StatusCode=['+response.statusCode+']. Body=['+body+']');
+        console.log('callRasterizer error:', effectiveError.message);
         rasterizerService.restartService();
-        return callback(new Error(body));
+        return callback(effectiveError);
       }
       callback(null);
     });


### PR DESCRIPTION
Hi,

I added the possibility to pass options to the PhantomJS command, as it may be useful and flexible.

I also added by default the option so that HTTPS websites are better supported by default.

See http://stackoverflow.com/questions/12021578/phantomjs-failing-to-open-https-site
