### PR TITLE
Dockerify screenshot as a service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:0.12.7
+
+ENV PHANTOMJS_VERSION 1.9.7
+RUN wget --no-check-certificate -q -O - https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$PHANTOMJS_VERSION-linux-x86_64.tar.bz2 | tar xvjC /opt
+RUN ln -s /opt/phantomjs-$PHANTOMJS_VERSION-linux-x86_64/bin/phantomjs /usr/bin/phantomjs
+
+ADD . /usr/screenshot-as-a-service
+WORKDIR /usr/screenshot-as-a-service
+RUN npm install
+
+EXPOSE 3000
+
+ENTRYPOINT node app

--- a/Readme.md
+++ b/Readme.md
@@ -6,15 +6,39 @@ A simple screenshot web service powered by [Express](http://expressjs.com) and [
 
 First [install](http://code.google.com/p/phantomjs/wiki/Installation) phantomjs, then clone this repo and install the deps:
 
-```
+```sh
 $ npm install
 ```
 
 Run the app:
 
-```
+```sh
 $ node app
 Express server listening on port 3000
+```
+
+## Setup with Docker
+
+First [install](https://docs.docker.com/#installation-guides) docker, then clone this repo and build docker image:
+
+```sh
+$ docker build -t [your_username]/screenshot-as-a-service .
+```
+
+Run the app:
+
+```sh
+$ docker run -d -p 80:3000 [your_username]/screenshot-as-a-service
+```
+
+Then access `[your-docker-ip]/`. See usage section below.
+
+If you need to override config, run the app as such:
+
+```sh
+$ docker run -d -p 80:3000 \
+  -v /path/to/config.yml:/usr/screenshot-as-a-service/config/default.yaml \
+  [your_username]/screenshot-as-a-service
 ```
 
 ## Usage

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -8,5 +8,5 @@ cache:
   lifetime: 60000      # one minute, set to 0 for no cache
 server:
   port: 3000           # main service port
-  host: '127.0.0.1'    # host to listen on
+  host: '0.0.0.0'      # host to listen on
   useCors: false       # enable CORS support


### PR DESCRIPTION
Add Dockerfile to start screenshot-as-a-service in only one command with Docker.
Inspired by #65 PR and the following Dockerfile: https://hub.docker.com/r/kpurdon/screenshot-as-a-service/
